### PR TITLE
Unalias ag on *nix since it clashes with silversearcher-ag

### DIFF
--- a/zshrc.d/05-aliases
+++ b/zshrc.d/05-aliases
@@ -6,6 +6,9 @@ alias e='$EDITOR'
 alias ae='vim ~/.zshrc.d/05-aliases && source ~/.zshrc.d/05-aliases'
 alias ze='vim ~/.zshrc && zgen reset && zsh'
 
+# Debian/Ubuntu
+unalias ag # remove apt-get alias in favor silversearcher-ag
+
 # Git
 alias ga='git add'
 alias gap='git add -p'


### PR DESCRIPTION
```sh-session
$ ag asd
Couldn't find package "asd".
```

:crying_cat_face: 