### PR TITLE
Prevent sourcing files in zshrc.d twice

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -159,18 +159,12 @@ bindkey "^N" insert-last-word
 bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"
 
 # Load supplementary aliases/functions/scripts
-for config in "${HOME}"/.zshrc.d/* ; do
-    source "$config"
-done
 for config in "$HOME"/.zshrc.d/**/* ; do
     source "$config"
 done
 
 # Load custom aliases/functions/scripts
 if [ -d "$HOME"/.dotfiles.local/zshrc.d ]; then
-    for config in "${HOME}"/.dotfiles.local/zshrc.d/* ; do
-        source "$config"
-    done
     for config in "$HOME"/.dotfiles.local/zshrc.d/**/* ; do
         source "$config"
     done


### PR DESCRIPTION
The `**/` is a recursive glob, including files in current and children directory.