### PR TITLE
Redirect error if there is no `ag` alias

### DIFF
--- a/zshrc.d/05-aliases
+++ b/zshrc.d/05-aliases
@@ -7,7 +7,7 @@ alias ae='vim ~/.zshrc.d/05-aliases && source ~/.zshrc.d/05-aliases'
 alias ze='vim ~/.zshrc && zgen reset && zsh'
 
 # Debian/Ubuntu
-unalias ag # remove apt-get alias in favor silversearcher-ag
+unalias ag 2>/dev/null # remove apt-get alias in favor silversearcher-ag
 
 # Git
 alias ga='git add'


### PR DESCRIPTION
Fixes error on OSX introduced in #19 - this alias is only set on Debian/Ubuntu.

    /Users/deizel/.zshrc.d/05-aliases:unalias:11: no such hash table element: ag