### PR TITLE
Replace current shell after using ze alias

### DIFF
--- a/zshrc.d/05-aliases
+++ b/zshrc.d/05-aliases
@@ -5,6 +5,7 @@ alias e='$EDITOR'
 # Config editing
 alias ae='vim ~/.zshrc.d/05-aliases && source ~/.zshrc.d/05-aliases'
 alias ze='vim ~/.zshrc && zgen reset && exec zsh'
+alias zr='exec zsh'
 
 # Debian/Ubuntu
 unalias ag # remove apt-get alias in favor silversearcher-ag

--- a/zshrc.d/05-aliases
+++ b/zshrc.d/05-aliases
@@ -4,7 +4,7 @@ alias e='$EDITOR'
 
 # Config editing
 alias ae='vim ~/.zshrc.d/05-aliases && source ~/.zshrc.d/05-aliases'
-alias ze='vim ~/.zshrc && zgen reset && zsh'
+alias ze='vim ~/.zshrc && zgen reset && exec zsh'
 
 # Debian/Ubuntu
 unalias ag # remove apt-get alias in favor silversearcher-ag


### PR DESCRIPTION
Use exec so we don't create a sub-shell each time.