### PR TITLE
Fixed warning after autosuggestion plugin update.

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -137,9 +137,6 @@ if ! zgen saved; then
 fi
 
 # Enable autosuggestions automatically.
-zle-line-init() {
-    zle autosuggest-start
-}
 zle -N zle-line-init
 
 # History settings


### PR DESCRIPTION
The `autosuggest-start` function was deprecated and the hack
is not needed anymore.

See tarruda/zsh-autosuggestions#9788c2e