### PR TITLE
Added `.phpintel` to global git ignore.

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -89,6 +89,7 @@ appengine-generated/
 # IDEs
 .idea/
 *.sublime-*
+.phpintel/
 
 # pre-commit
 .pre-commit-config.yaml


### PR DESCRIPTION
This is used by the SublimeText package of the same name to cache
code intel.